### PR TITLE
Fix CSS Parser

### DIFF
--- a/polyfill/polyfill.js
+++ b/polyfill/polyfill.js
@@ -85,7 +85,7 @@ function parseCSS(str) {
   }
   function parseWord(str, i) {
     const start = i;
-    while (i < str.length && /\w/.exec(str(i))) {
+    while (i < str.length && /\w/.exec(str[i])) {
       ++i;
     }
     return {word: str.substring(start, i), next: i};


### PR DESCRIPTION
Fixes “TypeError: str is not a function” thrown by `parseWord`.