### PR TITLE
improve keyboard and screen reader support for the scrollport

### DIFF
--- a/polyfill/polyfill.js
+++ b/polyfill/polyfill.js
@@ -230,6 +230,9 @@ function columnWidth(elem) {
 class FragmentNode {
   constructor(node) {
     this.container = document.createElement('fragments-container');
+    this.container.tabIndex = 0;
+    this.container.setAttribute('aria-label', 'Carousel scroll area');
+    this.container.setAttribute('role', 'group');
     this.node = node;
     this.fragments = {};
     let child = null;


### PR DESCRIPTION
Information on the [a11yproject](https://www.a11yproject.com/posts/how-to-use-the-tabindex-attribute/#:~:text=focus()%20method.-,Scrollable%20overflow%20containers,-tabindex%3D%220%22) site

this update introduced a bug when the scrollport is focused, it's bringing later items into view, maybe because it spans the width and it's trying to ensure it's all visible? will put this PR into draft until that issue has been resolved, but the intent of the PR can still exist here.